### PR TITLE
Support server local attributes

### DIFF
--- a/Ooui/Element.cs
+++ b/Ooui/Element.cs
@@ -9,6 +9,8 @@ namespace Ooui
     {
         readonly Dictionary<string, object> attributes = new Dictionary<string, object> ();
 
+        readonly Dictionary<string, object> localAttributes = new Dictionary<string, object> ();
+
         Document document = null;
 
         public string ClassName {
@@ -235,6 +237,21 @@ namespace Ooui
                     TargetId = Id,
                     Key = attributeName,
                 });
+            }
+        }
+
+        public void SetLocalAttribute (string attributeName, object value)
+        {
+            lock (localAttributes) {
+                localAttributes[attributeName] = value;
+            }
+        }
+
+        public object GetLocalAttribute (string attributeName)
+        {
+            lock (localAttributes) {
+                localAttributes.TryGetValue (attributeName, out var v);
+                return v;
             }
         }
 

--- a/Tests/ElementsTests.cs
+++ b/Tests/ElementsTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+#if NUNIT
+using NUnit.Framework;
+using TestClassAttribute = NUnit.Framework.TestFixtureAttribute;
+using TestMethodAttribute = NUnit.Framework.TestCaseAttribute;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+using Ooui;
+
+namespace Tests
+{
+    [TestClass]
+    public class ElementTests
+    {
+        [TestMethod]
+        public void LocalAttributes ()
+        {
+            var div = new Div ();
+            Assert.IsNull (div.GetLocalAttribute ("TestAttribute"));
+            div.SetLocalAttribute ("TestAttribute", "TestValue");
+            Assert.AreEqual ("TestValue", div.GetLocalAttribute ("TestAttribute"));
+            Assert.IsNull (div.GetAttribute ("TestAttribute"));
+        }
+    }
+}


### PR DESCRIPTION
Local attributes are not sent to browser. Local attributes are
useful for caching .NET objects on server side objects.