### PR TITLE
Added Node.ReplaceChildren and Node.ReplaceChildrenWith

### DIFF
--- a/Ooui/EventTarget.cs
+++ b/Ooui/EventTarget.cs
@@ -14,7 +14,9 @@ namespace Ooui
         readonly Dictionary<string, List<TargetEventHandler>> eventListeners =
             new Dictionary<string, List<TargetEventHandler>> ();
 
-        public string Id { get; protected set; } = GenerateId ();
+        public long PersistentId { get; } = GenerateId ();
+
+        public string Id { get; protected set; }
 
         public string TagName { get; private set; }
 
@@ -32,6 +34,7 @@ namespace Ooui
 
         protected EventTarget (string tagName)
         {
+            Id = $"{IdPrefix}{PersistentId}";
             TagName = tagName;
 
             Send (new Message {
@@ -105,10 +108,10 @@ namespace Ooui
         public const char IdPrefix = '\u2999';
 
         static long idCounter = 0;
-        static string GenerateId ()
+        static long GenerateId ()
         {
             var id = System.Threading.Interlocked.Increment (ref idCounter);
-            return $"{IdPrefix}{id}";
+            return id;
         }
 
         public void Send (Message message)

--- a/Tests/EventTargetTests.cs
+++ b/Tests/EventTargetTests.cs
@@ -21,5 +21,13 @@ namespace Tests
             var b = new Button ();
             Assert.AreEqual (1, b.StateMessages.Count);
         }
+
+        [TestMethod]
+        public void PersistentId ()
+        {
+            var div1 = new Div ();
+            var div2 = new Div ();
+            Assert.IsTrue (div2.PersistentId > div1.PersistentId);
+        }
     }
 }

--- a/Tests/NodeTests.cs
+++ b/Tests/NodeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 #if NUNIT
 using NUnit.Framework;
@@ -68,5 +69,84 @@ namespace Tests
             p.Receive (Message.Event (b.Id, "change", "please work"));
             Assert.AreEqual ("please work", b.Value);
         }
+
+        class TestDiv : Div
+        {
+            public TestDiv (string id)
+            {
+                Id = id;
+            }
+        }
+
+        [TestMethod]
+        public void ReplaceChildrenWith ()
+        {
+            // As ReplaceChildrenWith calls ReplaceChildren
+            //  this test also tests ReplaceChildren.
+
+            var parent = new TestDiv ("parent");
+            var child1 = new TestDiv ("child1");
+            var child2 = new TestDiv ("child2");
+            var child3 = new TestDiv ("child3");
+
+            // Log tracks all messages sent due to updates
+            var log    = new StringBuilder ();
+            log.AppendLine ();
+            void Parent_MessageSent(Message obj)
+            {
+                log.AppendLine (obj.ToString ());
+            }
+
+            parent.MessageSent += Parent_MessageSent;
+
+            Assert.AreEqual (parent.Children.Count, 0);
+
+            log.AppendLine ("#1 - Inserts child1 last");
+            parent.ReplaceChildrenWith (child1);
+            Assert.AreEqual (parent.Children.Count, 1);
+            Assert.AreEqual (child1.PersistentId, parent.Children[0].PersistentId);
+
+            log.AppendLine ("#2 - Inserts child2 before child1");
+            parent.ReplaceChildrenWith (child2, child1);
+            Assert.AreEqual (parent.Children.Count, 2);
+            Assert.AreEqual (child2.PersistentId, parent.Children[0].PersistentId);
+            Assert.AreEqual (child1.PersistentId, parent.Children[1].PersistentId);
+
+            log.AppendLine ("#3 - Inserts child1 before child2, inserts child 3 last");
+            parent.ReplaceChildrenWith (child1, child2, child3);
+            Assert.AreEqual (parent.Children.Count, 3);
+            Assert.AreEqual (child1.PersistentId, parent.Children[0].PersistentId);
+            Assert.AreEqual (child2.PersistentId, parent.Children[1].PersistentId);
+            Assert.AreEqual (child3.PersistentId, parent.Children[2].PersistentId);
+
+            log.AppendLine ("#4 - Inserts child2 before child1, removes child3 and child1");
+            parent.ReplaceChildrenWith (child2);
+            Assert.AreEqual (parent.Children.Count, 1);
+            Assert.AreEqual (child2.PersistentId, parent.Children[0].PersistentId);
+
+            log.AppendLine ("#5 - Removes child3");
+            parent.ReplaceChildrenWith ();
+            Assert.AreEqual (parent.Children.Count, 0);
+
+            var expected = @"
+#1 - Inserts child1 last
+{""m"":""call"",""id"":""parent"",""k"":""insertBefore"",""v"":[""child1"",null]}
+#2 - Inserts child2 before child1
+{""m"":""call"",""id"":""parent"",""k"":""insertBefore"",""v"":[""child2"",""child1""]}
+#3 - Inserts child1 before child2, inserts child 3 last
+{""m"":""call"",""id"":""parent"",""k"":""insertBefore"",""v"":[""child1"",""child2""]}
+{""m"":""call"",""id"":""parent"",""k"":""insertBefore"",""v"":[""child3"",null]}
+#4 - Inserts child2 before child1, removes child3 and child1
+{""m"":""call"",""id"":""parent"",""k"":""insertBefore"",""v"":[""child2"",""child1""]}
+{""m"":""call"",""id"":""parent"",""k"":""removeChild"",""v"":[""child3""]}
+{""m"":""call"",""id"":""parent"",""k"":""removeChild"",""v"":[""child1""]}
+#5 - Removes child3
+{""m"":""call"",""id"":""parent"",""k"":""removeChild"",""v"":[""child2""]}
+".Replace ("\r\n", "\n");
+
+            var actual = log.ToString ().Replace ("\r\n", "\n");
+            Assert.AreEqual (expected, actual);
+        }
+
     }
 }


### PR DESCRIPTION
This change was motivated by my work on Formlets for Ooui.

For Formlets to work I need an operation that allows me to update one or several children in a node. As the tree normally don't change that much it's desired that operations should be as few as possible.

Clearing and adding the children didn't work out for me as that lost the input focus.



