### PR TITLE
Add the ability to set ClassName from Xamarin Forms StyleId

### DIFF
--- a/Ooui.Forms/VisualElementRenderer.cs
+++ b/Ooui.Forms/VisualElementRenderer.cs
@@ -115,6 +115,7 @@ namespace Ooui.Forms
                 }
 
                 element.PropertyChanged += _propertyChangedHandler;
+                ClassName = Element?.StyleId;
             }
 
             OnElementChanged (new ElementChangedEventArgs<TElement> (oldElement, element));
@@ -142,6 +143,9 @@ namespace Ooui.Forms
             }
             else if (e.PropertyName == Layout.IsClippedToBoundsProperty.PropertyName) {
                 //UpdateClipToBounds ();
+            }
+            else if (e.PropertyName == "StyleId") {
+                ClassName = Element?.StyleId;
             }
         }
 

--- a/Ooui/Style.cs
+++ b/Ooui/Style.cs
@@ -20,6 +20,10 @@ namespace Ooui
             get => this["align-self"];
             set => this["align-self"] = value;
         }
+        public Value BackfaceVisibility {
+            get => this["backface-visibility"];
+            set => this["backface-visibility"] = value;
+        }
 
         public Value BackgroundColor {
             get => this["background-color"];
@@ -288,6 +292,11 @@ namespace Ooui
             }
         }
 
+        public Value Perspective {
+            get => this["perspective"];
+            set => this["perspective"] = value;
+        }
+
         public Value Position {
             get => this["position"];
             set => this["position"] = value;
@@ -321,6 +330,17 @@ namespace Ooui
         public Value TransformOrigin {
             get => this["transform-origin"];
             set => this["transform-origin"] = value;
+        }
+
+        public Value TransformStyle {
+            get => this["transform-style"];
+            set => this["transform-style"] = value;
+        }
+
+        public Value Transition
+        {
+            get => this["transition"];
+            set => this["transition"] = value;
         }
 
         public Value VerticalAlign {


### PR DESCRIPTION
I think this might be useful when using only Xamarin Forms to create the UI to be able to have css-classes defined in Forms that would then get picked up by Ooui.
Also added some style properties that can be used to do css-animations.
