### PR TITLE
Update Xamarin.Forms to v3.0.0 to fix https://github.com/praeclarum/Ooui/issues/26

### DIFF
--- a/Ooui.Forms/LocalIsolatedStorageFile.cs
+++ b/Ooui.Forms/LocalIsolatedStorageFile.cs
@@ -27,12 +27,12 @@ namespace Ooui.Forms
             throw new NotSupportedException ();
         }
 
-        public Task<Stream> OpenFileAsync (string path, Xamarin.Forms.Internals.FileMode mode, Xamarin.Forms.Internals.FileAccess access)
+        public Task<Stream> OpenFileAsync (string path, FileMode mode, FileAccess access)
         {
             throw new NotSupportedException ();
         }
 
-        public Task<Stream> OpenFileAsync (string path, Xamarin.Forms.Internals.FileMode mode, Xamarin.Forms.Internals.FileAccess access, Xamarin.Forms.Internals.FileShare share)
+        public Task<Stream> OpenFileAsync (string path, FileMode mode, FileAccess access, FileShare share)
         {
             throw new NotSupportedException ();
         }

--- a/Ooui.Forms/Ooui.Forms.csproj
+++ b/Ooui.Forms/Ooui.Forms.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/Ooui.Forms/Renderers/ButtonRenderer.cs
+++ b/Ooui.Forms/Renderers/ButtonRenderer.cs
@@ -65,7 +65,7 @@ namespace Ooui.Forms.Renderers
                 UpdateTextColor ();
             else if (e.PropertyName == Xamarin.Forms.Button.FontProperty.PropertyName)
                 UpdateFont ();
-            else if (e.PropertyName == Xamarin.Forms.Button.BorderWidthProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderRadiusProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderColorProperty.PropertyName)
+            else if (e.PropertyName == Xamarin.Forms.Button.BorderWidthProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.CornerRadiusProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderColorProperty.PropertyName)
                 UpdateBorder ();
             else if (e.PropertyName == Xamarin.Forms.Button.ImageProperty.PropertyName)
                 UpdateImage ();
@@ -96,7 +96,7 @@ namespace Ooui.Forms.Renderers
                 uiButton.Style.BorderWidth = null;
             }
 
-            var br = button.BorderRadius;
+            var br = button.CornerRadius;
             if (br > 0 && (bw > 0 || br != 5)) { // 5 is the default
                 uiButton.Style.BorderRadius = br + "px";
             }

--- a/Ooui.Forms/Renderers/FrameRenderer.cs
+++ b/Ooui.Forms/Renderers/FrameRenderer.cs
@@ -20,7 +20,7 @@ namespace Ooui.Forms.Renderers
             base.OnElementPropertyChanged (sender, e);
 
             if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
-                e.PropertyName == Xamarin.Forms.Frame.OutlineColorProperty.PropertyName ||
+                e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
                 e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
                 e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName)
                 SetupLayer ();
@@ -49,13 +49,13 @@ namespace Ooui.Forms.Renderers
                 //Layer.ShadowOpacity = 0;
             }
 
-            if (Element.OutlineColor == Xamarin.Forms.Color.Default) {
+            if (Element.BorderColor == Xamarin.Forms.Color.Default) {
                 Layer.BorderColor = Colors.Clear;
                 Layer.BorderWidth = 1;
                 Layer.BorderStyle = "none";
             }
             else {
-                Layer.BorderColor = Element.OutlineColor.ToOouiColor (Colors.Clear);
+                Layer.BorderColor = Element.BorderColor.ToOouiColor (Colors.Clear);
                 Layer.BorderWidth = 1;
                 Layer.BorderStyle = "solid";
             }

--- a/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
+++ b/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ msbuild
 dotnet run --project Samples/Samples.csproj --no-build
 ```
 
-*(There is currently an issue with Xamarin.Forms and building from the dotnet cli, so for now we use the msbuild command and then set the --no-build flag on dotnet run but this will eventually change when the issue is resolved.)*
-
 This will open the default starting page for the Samples. Now point your browser at [http://localhost:8080/shared-button](http://localhost:8080/shared-button)
 
 You should see a button that tracks the number of times it was clicked. The source code for that button is shown in the example below.

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
 	
   <ItemGroup>


### PR DESCRIPTION
Since Xamarin.Forms 3.0.0 is now stable, we can finally use it. So no more msbuild workaround… yay 🎉

I tested the self hosted and the ASP.NET version on Windows and MacOS using only .NET Core. Both worked without problems.

Can anyone test it using WASM? I haven’t setup the toolchain for it.

With the Update do come some minor API changes:

- `BorderRadius` is now `CornerRadius`

- `OutlineColorProperty` is now `BorderColorProperty`

- `OutlineColor` is now `BorderColor`

- `FileMode`, `FileAccess` and `FileShare` are now used from the `System.IO` namespace

