### PR TITLE
Fix the session handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Ooui.Wasm.Build.Tasks/linker"]
 	path = Ooui.Wasm.Build.Tasks/linker
-	url = git@github.com:mono/linker.git
+	url = https://github.com/mono/linker.git

--- a/Ooui.AspNetCore/ElementResult.cs
+++ b/Ooui.AspNetCore/ElementResult.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Ooui.Html;
 
 namespace Ooui.AspNetCore
 {

--- a/Ooui.AspNetCore/TagHelpers/OouiTagHelper.cs
+++ b/Ooui.AspNetCore/TagHelpers/OouiTagHelper.cs
@@ -4,7 +4,7 @@ namespace Ooui.AspNetCore.TagHelpers
 {
     public class OouiTagHelper : TagHelper
     {
-        public Ooui.Element Element { get; set; }
+        public Ooui.Html.Element Element { get; set; }
 
         public override void Process (TagHelperContext context, TagHelperOutput output)
         {

--- a/Ooui.AspNetCore/WebSocketHandler.cs
+++ b/Ooui.AspNetCore/WebSocketHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using System.IO;
 using Microsoft.Extensions.Logging;
+using Ooui.Html;
 
 namespace Ooui.AspNetCore
 {

--- a/Ooui.Forms/Cells/CellElement.cs
+++ b/Ooui.Forms/Cells/CellElement.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.ComponentModel;
 using Xamarin.Forms;
 

--- a/Ooui.Forms/Cells/CellRenderer.cs
+++ b/Ooui.Forms/Cells/CellRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Ooui.Forms.Extensions;
+using Ooui.Html;
 using System;
 using Xamarin.Forms;
 

--- a/Ooui.Forms/Cells/EntryCellElement.cs
+++ b/Ooui.Forms/Cells/EntryCellElement.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.ComponentModel;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Cells
 {
     public class EntryCellElement : CellElement
     {
-        public Label TextLabel { get; } = new Label ();
-        public TextInput TextInput { get; } = new TextInput ();
+        public Ooui.Html.Label TextLabel { get; } = new Ooui.Html.Label ();
+        public Ooui.Html.TextInput TextInput { get; } = new Ooui.Html.TextInput ();
 
         public EntryCellElement ()
         {

--- a/Ooui.Forms/Cells/ImageCellElement.cs
+++ b/Ooui.Forms/Cells/ImageCellElement.cs
@@ -10,11 +10,11 @@ namespace Ooui.Forms.Cells
 {
     public class ImageCellElement : CellElement
     {
-        public Image ImageView { get; } = new Image ();
+        public Ooui.Html.Image ImageView { get; } = new Ooui.Html.Image ();
 
-        public Label TextLabel { get; } = new Label ();
+        public Ooui.Html.Label TextLabel { get; } = new Ooui.Html.Label ();
 
-        public Label DetailTextLabel { get; } = new Label ();
+        public Ooui.Html.Label DetailTextLabel { get; } = new Ooui.Html.Label ();
 
         public ImageCellElement ()
         {

--- a/Ooui.Forms/Cells/SwitchCellElement.cs
+++ b/Ooui.Forms/Cells/SwitchCellElement.cs
@@ -8,7 +8,7 @@ namespace Ooui.Forms.Cells
 {
     public class SwitchCellElement : CellElement
     {
-        public Label TextLabel { get; } = new Label ();
+        public Ooui.Html.Label TextLabel { get; } = new Ooui.Html.Label ();
         public SwitchRenderer.SwitchElement Switch { get; } = new SwitchRenderer.SwitchElement ();
 
         public SwitchCellElement ()

--- a/Ooui.Forms/Cells/TextCellElement.cs
+++ b/Ooui.Forms/Cells/TextCellElement.cs
@@ -7,9 +7,9 @@ namespace Ooui.Forms.Cells
 {
     public class TextCellElement : CellElement
     {
-        public Label TextLabel { get; } = new Label ();
+        public Ooui.Html.Label TextLabel { get; } = new Ooui.Html.Label ();
 
-        public Label DetailTextLabel { get; } = new Label ();
+        public Ooui.Html.Label DetailTextLabel { get; } = new Ooui.Html.Label ();
 
         public TextCellElement ()
         {

--- a/Ooui.Forms/DisplayAlert.cs
+++ b/Ooui.Forms/DisplayAlert.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Xamarin.Forms.Internals;
+using Ooui.Html;
 
 namespace Ooui.Forms
 {

--- a/Ooui.Forms/EventTracker.cs
+++ b/Ooui.Forms/EventTracker.cs
@@ -5,7 +5,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Xamarin.Forms;
 
-using NativeView = Ooui.Element;
+using NativeView = Ooui.Html.Element;
 
 namespace Ooui.Forms
 {
@@ -153,12 +153,12 @@ namespace Ooui.Forms
             return null;
         }
 
-        static void AddGestureRecognizer (Element element, NativeGestureRecognizer recognizer)
+        static void AddGestureRecognizer (Ooui.Html.Element element, NativeGestureRecognizer recognizer)
         {
             element.AddEventListener (recognizer.EventType, recognizer.Handler);
         }
 
-        static void RemoveGestureRecognizer (Element element, NativeGestureRecognizer recognizer)
+        static void RemoveGestureRecognizer (Ooui.Html.Element element, NativeGestureRecognizer recognizer)
         {
             element.RemoveEventListener (recognizer.EventType, recognizer.Handler);
         }

--- a/Ooui.Forms/Exports.cs
+++ b/Ooui.Forms/Exports.cs
@@ -25,6 +25,7 @@ using Xamarin.Forms;
 [assembly: ExportRenderer (typeof (Switch), typeof (SwitchRenderer))]
 [assembly: ExportRenderer (typeof (TimePicker), typeof (TimePickerRenderer))]
 [assembly: ExportRenderer (typeof (WebView), typeof (WebViewRenderer))]
+[assembly: ExportRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer))]
 [assembly: ExportImageSourceHandler (typeof (FileImageSource), typeof (FileImageSourceHandler))]
 [assembly: ExportImageSourceHandler (typeof (StreamImageSource), typeof (StreamImagesourceHandler))]
 [assembly: ExportImageSourceHandler (typeof (UriImageSource), typeof (ImageLoaderSourceHandler))]

--- a/Ooui.Forms/Extensions/ElementExtensions.cs
+++ b/Ooui.Forms/Extensions/ElementExtensions.cs
@@ -5,7 +5,7 @@ namespace Ooui.Forms.Extensions
 {
     public static class ElementExtensions
     {
-        public static SizeRequest GetSizeRequest (this Ooui.Element self, double widthConstraint, double heightConstraint,
+        public static SizeRequest GetSizeRequest (this Ooui.Html.Element self, double widthConstraint, double heightConstraint,
             double minimumWidth = -1, double minimumHeight = -1)
         {
             var rw = 0.0;

--- a/Ooui.Forms/Extensions/ElementExtensions.cs
+++ b/Ooui.Forms/Extensions/ElementExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Extensions
@@ -37,6 +38,79 @@ namespace Ooui.Forms.Extensions
                 minimumHeight < 0 ? rh : minimumHeight);
 
             return new SizeRequest (new Size (rw, rh), minimum);
+        }
+
+        public static IEnumerable<T> CollectElements<T>(this Xamarin.Forms.Element element) where T : Xamarin.Forms.Element {
+            if (element == null)
+                yield break;
+
+            foreach (var child in element.GetChildrenRecursive())
+                if (typeof(T).IsAssignableFrom(child.GetType()))
+                    yield return child as T;
+
+
+            /*var typ = element.GetType();
+
+            if (typeof(Cell).IsAssignableFrom(typeof(T)))
+                callHandler(element as T);
+
+            if (typeof(Cell).IsAssignableFrom(typ)) {
+                var cell = element as Cell;
+                if (typeof(ViewCell).IsAssignableFrom(typ))
+                    CollectElements<T>((cell as ViewCell).View, callHandler);
+            } else if (typeof(ContentPage).IsAssignableFrom(typ)) {
+                var page = element as ContentPage;
+                CollectElements<T>(page.Content, callHandler);
+            } else if (typeof(Layout<View>).IsAssignableFrom(typ)) {
+                var layout = element as Layout<View>;
+                foreach (var child in layout.Children)
+                    CollectElements<T>(child, callHandler);
+            } else if (typeof(Layout).IsAssignableFrom(typ)) {
+                var layout = element as Layout;
+                foreach (var child in layout.Children)
+                    CollectElements<T>(child, callHandler);
+            } else if (typeof(ITemplatedItemsView<Cell>).IsAssignableFrom(typ)) {
+                var tiv = element as ITemplatedItemsView<Cell>;
+                foreach (var cell in tiv.TemplatedItems)
+                    CollectElements<T>(cell, callHandler);
+            }*/
+        }
+
+        public static IEnumerable<Xamarin.Forms.Element> GetChildren(this Xamarin.Forms.Element element) {
+            if (element == null)
+                yield break;
+
+            var typ = element.GetType();
+
+            if (typeof(Cell).IsAssignableFrom(typ)) {
+                var cell = element as Cell;
+                if (typeof(ViewCell).IsAssignableFrom(typ))
+                    yield return (element as ViewCell).View;
+            } else if (typeof(ContentPage).IsAssignableFrom(typ)) {
+                var page = element as ContentPage;
+                yield return page.Content;
+            } else if (typeof(Layout<View>).IsAssignableFrom(typ)) {
+                var layout = element as Layout<View>;
+                foreach (var child in layout.Children)
+                    yield return child;
+            } else if (typeof(Layout).IsAssignableFrom(typ)) {
+                var layout = element as Layout;
+                foreach (var child in layout.Children)
+                    yield return child;
+            } else if (typeof(ITemplatedItemsView<Cell>).IsAssignableFrom(typ)) {
+                var tiv = element as ITemplatedItemsView<Cell>;
+                foreach (var cell in tiv.TemplatedItems)
+                    yield return cell;
+            }
+            yield break;
+        }
+
+        public static IEnumerable<Xamarin.Forms.Element> GetChildrenRecursive(this Xamarin.Forms.Element element) {
+            foreach (var child in element.GetChildren()) {
+                yield return child;
+                foreach (var gchild in GetChildrenRecursive(child))
+                    yield return gchild;
+            }
         }
     }
 }

--- a/Ooui.Forms/Extensions/ListViewExtensions.cs
+++ b/Ooui.Forms/Extensions/ListViewExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Ooui.Forms.Extensions
+{
+    public static class ListViewExtensions
+    {
+        public static void UpdateChildrenSize(this ListView self) {
+            var pos = new Point(self.X, self.Y);
+            var size = new Size(self.Width, 999999);
+
+            foreach (var cell in self.TemplatedItems) {
+                if (!typeof(ViewCell).IsAssignableFrom(cell.GetType()))
+                    continue;
+                var viewCell = cell as ViewCell;
+
+                if (viewCell.View == null)
+                    continue;
+
+                var view = viewCell.View;
+
+                view.VerticalOptions = LayoutOptions.Start;
+                Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(
+                    view,
+                    new Rectangle(pos, size));
+
+                pos.Y += view.Height;
+            }
+
+            if (self.Height < pos.Y)
+                self.HeightRequest = pos.Y;
+        }
+    }
+}

--- a/Ooui.Forms/Forms.cs
+++ b/Ooui.Forms/Forms.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms
 
         public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;
 
-        public static void SendViewInitialized (this VisualElement self, Ooui.Element nativeView)
+        public static void SendViewInitialized (this VisualElement self, Ooui.Html.Element nativeView)
         {
             ViewInitialized?.Invoke (self, new ViewInitializedEventArgs { View = self, NativeView = nativeView });
         }
@@ -148,7 +148,7 @@ namespace Xamarin.Forms
         public class ViewInitializedEventArgs
         {
             public VisualElement View { get; set; }
-            public Ooui.Element NativeView { get; set; }
+            public Ooui.Html.Element NativeView { get; set; }
         }
 
         public static void LoadApplication (Application application)

--- a/Ooui.Forms/IVisualElementRenderer.cs
+++ b/Ooui.Forms/IVisualElementRenderer.cs
@@ -9,7 +9,7 @@ namespace Ooui.Forms
 
 		VisualElement Element { get; }
 
-		Ooui.Element NativeView { get; }
+		Ooui.Html.Element NativeView { get; }
 
 		void SetElement (VisualElement element);
 

--- a/Ooui.Forms/LocalIsolatedStorageFile.cs
+++ b/Ooui.Forms/LocalIsolatedStorageFile.cs
@@ -27,12 +27,12 @@ namespace Ooui.Forms
             throw new NotSupportedException ();
         }
 
-        public Task<Stream> OpenFileAsync (string path, Xamarin.Forms.Internals.FileMode mode, Xamarin.Forms.Internals.FileAccess access)
+        public Task<Stream> OpenFileAsync (string path, FileMode mode, FileAccess access)
         {
             throw new NotSupportedException ();
         }
 
-        public Task<Stream> OpenFileAsync (string path, Xamarin.Forms.Internals.FileMode mode, Xamarin.Forms.Internals.FileAccess access, Xamarin.Forms.Internals.FileShare share)
+        public Task<Stream> OpenFileAsync (string path, FileMode mode, FileAccess access, FileShare share)
         {
             throw new NotSupportedException ();
         }

--- a/Ooui.Forms/Ooui.Forms.csproj
+++ b/Ooui.Forms/Ooui.Forms.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/Ooui.Forms/Ooui.Forms.csproj
+++ b/Ooui.Forms/Ooui.Forms.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Extensions\" />
     <Folder Include="Controls\" />
   </ItemGroup>
   <ItemGroup>

--- a/Ooui.Forms/Ooui.Forms.csproj
+++ b/Ooui.Forms/Ooui.Forms.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/Ooui.Forms/PageExtensions.cs
+++ b/Ooui.Forms/PageExtensions.cs
@@ -12,11 +12,11 @@ namespace Xamarin.Forms
 
         public static void PublishShared (this Xamarin.Forms.Page page, string path)
         {
-            var lazyPage = new Lazy<Ooui.Element> ((() => page.CreateElement ()), true);
+            var lazyPage = new Lazy<Ooui.Html.Element> ((() => page.CreateElement ()), true);
             Ooui.UI.Publish (path, () => lazyPage.Value);
         }
 
-        public static Ooui.Element GetOouiElement (this Xamarin.Forms.Page page)
+        public static Ooui.Html.Element GetOouiElement (this Xamarin.Forms.Page page)
         {
             if (!Xamarin.Forms.Forms.IsInitialized)
                 throw new InvalidOperationException ("call Forms.Init() before this");
@@ -30,7 +30,7 @@ namespace Xamarin.Forms
             return CreateElement (page);
         }
 
-        static Ooui.Element CreateElement (this Xamarin.Forms.Page page)
+        static Ooui.Html.Element CreateElement (this Xamarin.Forms.Page page)
         {
             if (!(page.RealParent is Application)) {
                 var app = new DefaultApplication ();

--- a/Ooui.Forms/Platform.cs
+++ b/Ooui.Forms/Platform.cs
@@ -13,7 +13,7 @@ namespace Ooui.Forms
 
         readonly PlatformRenderer _renderer;
 
-        public Ooui.Element Element => _renderer;
+        public Ooui.Html.Element Element => _renderer;
 
         public Page Page { get; private set; }
 

--- a/Ooui.Forms/PlatformEffect.cs
+++ b/Ooui.Forms/PlatformEffect.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms;
 
 namespace Ooui.Forms
 {
-	public abstract class PlatformEffect : PlatformEffect<Ooui.Element, Ooui.Element>
+	public abstract class PlatformEffect : PlatformEffect<Ooui.Html.Element, Ooui.Html.Element>
 	{
 	}
 }

--- a/Ooui.Forms/PlatformRenderer.cs
+++ b/Ooui.Forms/PlatformRenderer.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms;
 
 namespace Ooui.Forms
 {
-    public class PlatformRenderer : Ooui.Div, IDisposable
+    public class PlatformRenderer : Ooui.Html.Div, IDisposable
 	{
 		readonly Platform platform;
 

--- a/Ooui.Forms/Renderers/ActivityIndicatorRenderer.cs
+++ b/Ooui.Forms/Renderers/ActivityIndicatorRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using Xamarin.Forms;
+using Ooui.Html;
 
 namespace Ooui.Forms.Renderers
 {

--- a/Ooui.Forms/Renderers/ButtonRenderer.cs
+++ b/Ooui.Forms/Renderers/ButtonRenderer.cs
@@ -65,7 +65,7 @@ namespace Ooui.Forms.Renderers
                 UpdateTextColor ();
             else if (e.PropertyName == Xamarin.Forms.Button.FontProperty.PropertyName)
                 UpdateFont ();
-            else if (e.PropertyName == Xamarin.Forms.Button.BorderWidthProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderRadiusProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderColorProperty.PropertyName)
+            else if (e.PropertyName == Xamarin.Forms.Button.BorderWidthProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.CornerRadiusProperty.PropertyName || e.PropertyName == Xamarin.Forms.Button.BorderColorProperty.PropertyName)
                 UpdateBorder ();
             else if (e.PropertyName == Xamarin.Forms.Button.ImageProperty.PropertyName)
                 UpdateImage ();
@@ -96,7 +96,7 @@ namespace Ooui.Forms.Renderers
                 uiButton.Style.BorderWidth = null;
             }
 
-            var br = button.BorderRadius;
+            var br = button.CornerRadius;
             if (br > 0 && (bw > 0 || br != 5)) { // 5 is the default
                 uiButton.Style.BorderRadius = br + "px";
             }

--- a/Ooui.Forms/Renderers/ButtonRenderer.cs
+++ b/Ooui.Forms/Renderers/ButtonRenderer.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers
 {
-    public class ButtonRenderer : ViewRenderer<Xamarin.Forms.Button, Ooui.Button>
+    public class ButtonRenderer : ViewRenderer<Xamarin.Forms.Button, Ooui.Html.Button>
     {
         Ooui.Color _buttonTextColorDefaultDisabled;
         Ooui.Color _buttonTextColorDefaultHighlighted;
@@ -34,7 +34,7 @@ namespace Ooui.Forms.Renderers
 
             if (e.NewElement != null) {
                 if (Control == null) {
-                    SetNativeControl (new Ooui.Button ());
+                    SetNativeControl (new Ooui.Html.Button ());
 
                     Debug.Assert (Control != null, "Control != null");
 

--- a/Ooui.Forms/Renderers/DatePickerRenderer.cs
+++ b/Ooui.Forms/Renderers/DatePickerRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Xamarin.Forms;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 
 namespace Ooui.Forms.Renderers
 {

--- a/Ooui.Forms/Renderers/EditorRenderer.cs
+++ b/Ooui.Forms/Renderers/EditorRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Xamarin.Forms;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 
 namespace Ooui.Forms.Renderers
 {

--- a/Ooui.Forms/Renderers/EntryRenderer.cs
+++ b/Ooui.Forms/Renderers/EntryRenderer.cs
@@ -2,11 +2,12 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers
 {
-    public class EntryRenderer : ViewRenderer<Entry, Ooui.TextInput>
+    public class EntryRenderer : ViewRenderer<Entry, TextInput>
     {
         bool _disposed;
 
@@ -64,7 +65,7 @@ namespace Ooui.Forms.Renderers
             e.NewElement.FocusChangeRequested += Element_FocusChangeRequested;
 
             if (Control == null) {
-                var textField = new Ooui.TextInput ();
+                var textField = new Ooui.Html.TextInput ();
                 SetNativeControl (textField);
 
                 Debug.Assert (Control != null, "Control != null");

--- a/Ooui.Forms/Renderers/FrameRenderer.cs
+++ b/Ooui.Forms/Renderers/FrameRenderer.cs
@@ -20,7 +20,7 @@ namespace Ooui.Forms.Renderers
             base.OnElementPropertyChanged (sender, e);
 
             if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
-                e.PropertyName == Xamarin.Forms.Frame.OutlineColorProperty.PropertyName ||
+                e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
                 e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
                 e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName)
                 SetupLayer ();
@@ -49,13 +49,13 @@ namespace Ooui.Forms.Renderers
                 //Layer.ShadowOpacity = 0;
             }
 
-            if (Element.OutlineColor == Xamarin.Forms.Color.Default) {
+            if (Element.BorderColor == Xamarin.Forms.Color.Default) {
                 Layer.BorderColor = Colors.Clear;
                 Layer.BorderWidth = 1;
                 Layer.BorderStyle = "none";
             }
             else {
-                Layer.BorderColor = Element.OutlineColor.ToOouiColor (Colors.Clear);
+                Layer.BorderColor = Element.BorderColor.ToOouiColor (Colors.Clear);
                 Layer.BorderWidth = 1;
                 Layer.BorderStyle = "solid";
             }

--- a/Ooui.Forms/Renderers/ImageRenderer.cs
+++ b/Ooui.Forms/Renderers/ImageRenderer.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers
 {
-    public class ImageRenderer : ViewRenderer<Xamarin.Forms.Image, Ooui.Image>
+    public class ImageRenderer : ViewRenderer<Xamarin.Forms.Image, Ooui.Html.Image>
     {
         bool _isDisposed;
 
@@ -26,7 +26,7 @@ namespace Ooui.Forms.Renderers
         protected override async void OnElementChanged (ElementChangedEventArgs<Xamarin.Forms.Image> e)
         {
             if (Control == null) {
-                var imageView = new Ooui.Image ();
+                var imageView = new Ooui.Html.Image ();
                 SetNativeControl (imageView);
                 this.Style.Overflow = "hidden";
             }

--- a/Ooui.Forms/Renderers/LabelRenderer.cs
+++ b/Ooui.Forms/Renderers/LabelRenderer.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using Ooui.Forms.Extensions;
 using Xamarin.Forms;
 
-using NativeLabel = Ooui.Span;
+using NativeLabel = Ooui.Html.Span;
 
 namespace Ooui.Forms.Renderers
 {

--- a/Ooui.Forms/Renderers/LabelRenderer.cs
+++ b/Ooui.Forms/Renderers/LabelRenderer.cs
@@ -104,6 +104,8 @@ namespace Ooui.Forms.Renderers
         {
             this.Style.Display = "table";
             Control.Style.Display = "table-cell";
+            this.Style.WhiteSpace = "pre-wrap";
+            Control.Style.WhiteSpace = "pre-wrap";
             this.Style.TextAlign = Element.HorizontalTextAlignment.ToOouiTextAlign ();
             Control.Style.VerticalAlign = Element.VerticalTextAlignment.ToOouiVerticalAlign ();
         }

--- a/Ooui.Forms/Renderers/LinkLabelRenderer.cs
+++ b/Ooui.Forms/Renderers/LinkLabelRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers

--- a/Ooui.Forms/Renderers/LinkViewRenderer.cs
+++ b/Ooui.Forms/Renderers/LinkViewRenderer.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.ComponentModel;
 
 namespace Ooui.Forms.Renderers
 {
-    public class LinkViewRenderer : ViewRenderer<LinkView, Ooui.Anchor>
+    public class LinkViewRenderer : ViewRenderer<LinkView, Anchor>
     {
         public LinkViewRenderer ()
             : base ("a")

--- a/Ooui.Forms/Renderers/ListViewRenderer.cs
+++ b/Ooui.Forms/Renderers/ListViewRenderer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 using Ooui.Forms.Cells;
+using Ooui.Html;
 
 namespace Ooui.Forms.Renderers
 {
@@ -83,7 +84,7 @@ namespace Ooui.Forms.Renderers
             if (Control == null)
                 return;
             foreach (var c in Control.Children) {
-                if (c is Element e)
+                if (c is Html.Element e)
                     e.Click -= ListItem_Click;
             }
         }

--- a/Ooui.Forms/Renderers/NavigationPageRenderer.cs
+++ b/Ooui.Forms/Renderers/NavigationPageRenderer.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Net;
+using System.Text;
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+namespace Ooui.Forms.Renderers
+{
+    public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>
+    {
+        private Stack<DefaultRenderer> backElementStack = new Stack<DefaultRenderer>();
+        private Stack<DefaultRenderer> forwardElementStack = new Stack<DefaultRenderer>();
+        // required hack to make sure a browser nav event (back and forward buttons) don't trigger the commands to pushState or go back on the browser AGAIN
+        bool ignoreNavEventFlag = false;
+
+        private string ns;
+        private string assemblyName;
+
+        protected override void OnElementChanged(ElementChangedEventArgs<NavigationPage> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null)
+            {
+                e.OldElement.PushRequested -= OnPushRequested;
+                e.OldElement.PopRequested -= OnPopRequested;
+                e.OldElement.PopToRootRequested -= OnPopToRootRequested;
+                e.OldElement.InternalChildren.CollectionChanged -= OnChildrenChanged;
+                e.OldElement.PropertyChanged -= OnElementPropertyChanged;
+            }
+            if (e.NewElement != null)
+            {
+                e.NewElement.PushRequested += OnPushRequested;
+                e.NewElement.PopRequested += OnPopRequested;
+                e.NewElement.PopToRootRequested += OnPopToRootRequested;
+                e.NewElement.InternalChildren.CollectionChanged += OnChildrenChanged;
+                e.NewElement.PropertyChanged += OnElementPropertyChanged;
+
+                GetAssemblyInfoForRootPage();
+            }                        
+        }
+               
+        protected override bool TriggerEventFromMessage(Message message)
+        {
+            if (message.TargetId == "window" && message.Key == "hashchange" && message.Value is Newtonsoft.Json.Linq.JObject k)
+            {
+                ProcessHash((string)k["hash"]);
+                return true;
+            }
+            else
+                return base.TriggerEventFromMessage(message);
+        }
+
+        //signaling doesn't seem to work until child has been inserted into document, so wait for this and then adjust the hash for direct navigation
+        protected override void OnChildInsertedBefore(Node newChild, Node referenceChild)
+        {
+            base.OnChildInsertedBefore(newChild, referenceChild);
+
+            var index = this.Children.IndexOf(newChild);
+            if (index - 1 >= 0)
+                (this.Children[index - 1] as Element).Style.Display = "none";
+            
+            this.backElementStack.Push(newChild as DefaultRenderer);
+
+            if (this.ignoreNavEventFlag)
+                this.ignoreNavEventFlag = false;
+            else
+            {
+                this.forwardElementStack.Clear();
+                this.NativeView.Document.Window.Call("history.pushState", null, null, GenerateFullHash());
+            }
+        }
+
+        protected override void OnChildRemoved(Node child)
+        {
+            base.OnChildRemoved(child);
+
+            if (this.Children.Count > 0)
+                (this.Children.Last() as Element).Style.Display = "block";
+
+            DefaultRenderer popped = this.backElementStack.Pop();
+            this.forwardElementStack.Push(child as DefaultRenderer);
+
+            if (this.ignoreNavEventFlag)
+                this.ignoreNavEventFlag = false;
+            else
+                this.NativeView.Document.Window.Call("history.back");
+        }
+
+        //only called when user types url manually OR clicks forward or back in the browser OR very beginning of navigation (backStack has first element already though)
+        private void ProcessHash(string fullHash)
+        {
+            IEnumerable<string> browserPageArray;
+            if (fullHash.Length > 0)
+                browserPageArray = fullHash.Split('/').Select(x => x == "#" ? this.backElementStack.Last().Element.GetType().Name : x);
+            else
+                browserPageArray = new string[] { this.backElementStack.Last().Element.GetType().Name };
+
+            // if current hash doesn't match up with the current page displayed (which is the first/most recent one in the backHashStack)
+            if (backElementStack.First().Element.GetType().Name != browserPageArray.Last())
+            {
+                // see if the last hash item is in the backStack (nav backwards) OR in the forward stack (nav forwards) OR not there at all (regenerate stack)
+                var lastPageFromBackStack = backElementStack.FirstOrDefault(x => x.Element.GetType().Name == browserPageArray.Last());//.Cast<(Page page, string hash)?>().FirstOrDefault();
+                var lastPageFromForwardStack = forwardElementStack.FirstOrDefault(x => x.Element.GetType().Name == browserPageArray.Last());//.Cast<(Page page, string hash)?>().FirstOrDefault();
+
+                // just need to adjust internal stack and page view
+                // case clicked back button
+                if (lastPageFromBackStack != null)
+                {
+                    var peeked = this.backElementStack.Peek();
+                    this.ignoreNavEventFlag = true;
+                    this.Element.PopAsync();
+                }
+                // case for clicking forward
+                else if (lastPageFromForwardStack != null)
+                {
+                    var popped = this.forwardElementStack.Pop();
+                    this.ignoreNavEventFlag = true;
+
+                    // *** This should work, but the result is a page that doesn't format correctly.  Instead, we'll have to create new pages from scratch.
+                    //this.Element.PushAsync(popped.Element as Page);
+                    this.Element.PushAsync((Page)Activator.CreateInstance(Type.GetType($"{this.ns}.{popped.Element.GetType().Name}, {this.assemblyName}")));
+                }
+                // case for someone typing in url from scratch with hash
+                else
+                {
+                    //assume someone put the url into the browser manually from scratch
+                    //first replace the current state with # only.
+                    this.Document.Window.Call("history.replaceState", null, null, GenerateFullHash());
+                    foreach (var pageName in browserPageArray.Where(x=> x != backElementStack.Last().Element.GetType().Name))
+                    {
+                        var pageTypeName = WebUtility.HtmlDecode(pageName);
+                        var pageInstance = Activator.CreateInstance(Type.GetType($"{this.ns}.{pageTypeName}, {this.assemblyName}"));
+                        this.Element.PushAsync(pageInstance as Page);
+                    }
+                }
+            }
+        }
+
+        // Reflection needs more than just the name to create an instance from a string.
+        private void GetAssemblyInfoForRootPage()
+        {
+            if (this.Element.Navigation.NavigationStack.Count > 0)
+            {
+                var page = this.Element.Navigation.NavigationStack.Last();
+                var type = page.GetType();
+                this.ns = type.Namespace;
+                this.assemblyName = type.Assembly.FullName;
+            }
+        }
+                
+        // This is where you would normally set back button state based on what's in the stack.
+        private void OnChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            // Not needed for browser... back button is always available.
+        }
+
+        private void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
+        {
+            e.Realize = true;
+        }
+
+        private void OnPopRequested(object sender, NavigationRequestedEventArgs e)
+        {
+            e.Realize = true;
+        }
+
+        // This is where you would draw the new contents.
+        private void OnPushRequested(object sender, NavigationRequestedEventArgs e)
+        {
+            e.Realize = true;
+        }
+
+        private string GenerateFullHash()
+        {
+            string hashString = "";
+            bool started = false;
+            foreach (var i in this.backElementStack.Reverse())
+            {
+                if (started)
+                    hashString += "/" + i.Element.GetType().Name;
+                else
+                {
+                    started = true;
+                    hashString += "#";
+                }
+            }
+            return hashString;
+        }
+        
+    }
+}

--- a/Ooui.Forms/Renderers/NavigationPageRenderer.cs
+++ b/Ooui.Forms/Renderers/NavigationPageRenderer.cs
@@ -62,7 +62,7 @@ namespace Ooui.Forms.Renderers
 
             var index = this.Children.IndexOf(newChild);
             if (index - 1 >= 0)
-                (this.Children[index - 1] as Element).Style.Display = "none";
+                (this.Children[index - 1] as Ooui.Html.Element).Style.Display = "none";
             
             this.backElementStack.Push(newChild as DefaultRenderer);
 
@@ -80,7 +80,7 @@ namespace Ooui.Forms.Renderers
             base.OnChildRemoved(child);
 
             if (this.Children.Count > 0)
-                (this.Children.Last() as Element).Style.Display = "block";
+                (this.Children.Last() as Ooui.Html.Element).Style.Display = "block";
 
             DefaultRenderer popped = this.backElementStack.Pop();
             this.forwardElementStack.Push(child as DefaultRenderer);

--- a/Ooui.Forms/Renderers/PickerRenderer.cs
+++ b/Ooui.Forms/Renderers/PickerRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Ooui.Forms.Extensions;
+using Ooui.Html;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/Ooui.Forms/Renderers/ProgressBarRenderer.cs
+++ b/Ooui.Forms/Renderers/ProgressBarRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using Xamarin.Forms;

--- a/Ooui.Forms/Renderers/SearchBarRenderer.cs
+++ b/Ooui.Forms/Renderers/SearchBarRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Ooui.Forms.Extensions;
+using Ooui.Html;
 using System;
 using System.ComponentModel;
 using Xamarin.Forms;
@@ -8,7 +9,7 @@ namespace Ooui.Forms.Renderers
     public class SearchBarRenderer : ViewRenderer<SearchBar, Div>
     {
         Input _searchBar;
-        Button _searchButton;
+        Html.Button _searchButton;
         bool _disposed;
 
         IElementController ElementController => Element as IElementController;
@@ -62,8 +63,8 @@ namespace Ooui.Forms.Renderers
             if (Control == null)
             {
                 var p = new Div { ClassName = "input-group" };
-                var pb = new Span { ClassName = "input-group-btn" };
-                _searchButton = new Button { ClassName = "btn btn-secondary", Text = "Search" };
+                var pb = new Html.Span { ClassName = "input-group-btn" };
+                _searchButton = new Html.Button { ClassName = "btn btn-secondary", Text = "Search" };
                 pb.AppendChild(_searchButton);
                 _searchBar = new Input
                 {

--- a/Ooui.Forms/Renderers/SliderRenderer.cs
+++ b/Ooui.Forms/Renderers/SliderRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using Ooui.Html;
+using System.ComponentModel;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers

--- a/Ooui.Forms/Renderers/SwitchRenderer.cs
+++ b/Ooui.Forms/Renderers/SwitchRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers

--- a/Ooui.Forms/Renderers/TimePickerRenderer.cs
+++ b/Ooui.Forms/Renderers/TimePickerRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Xamarin.Forms;
 using Ooui.Forms.Extensions;
+using Ooui.Html;
 
 namespace Ooui.Forms.Renderers
 {

--- a/Ooui.Forms/Renderers/ViewRenderer.cs
+++ b/Ooui.Forms/Renderers/ViewRenderer.cs
@@ -5,11 +5,11 @@ using Xamarin.Forms;
 
 namespace Ooui.Forms.Renderers
 {
-    public abstract class ViewRenderer : ViewRenderer<View, Ooui.Element>
+    public abstract class ViewRenderer : ViewRenderer<View, Ooui.Html.Element>
     {
     }
 
-	public class ViewRenderer<TElement, TNativeElement> : VisualElementRenderer<TElement> where TElement : View where TNativeElement : Ooui.Element
+	public class ViewRenderer<TElement, TNativeElement> : VisualElementRenderer<TElement> where TElement : View where TNativeElement : Ooui.Html.Element
 	{
 		public TNativeElement Control { get; private set; }
 
@@ -86,7 +86,7 @@ namespace Ooui.Forms.Renderers
             Control.Style.BackgroundColor = color.ToOouiColor (OouiTheme.BackgroundColor);
 		}
 
-        protected void SetNativeControl (Ooui.Element element)
+        protected void SetNativeControl (Ooui.Html.Element element)
 		{
 			Control = (TNativeElement)element;
 
@@ -106,7 +106,7 @@ namespace Ooui.Forms.Renderers
             }
         }
 
-		protected override void SendVisualElementInitialized (VisualElement element, Ooui.Element nativeView)
+		protected override void SendVisualElementInitialized (VisualElement element, Ooui.Html.Element nativeView)
 		{
 			base.SendVisualElementInitialized (element, Control);
 		}
@@ -116,7 +116,7 @@ namespace Ooui.Forms.Renderers
 			if (Element == null || Control == null)
 				return;
 
-			var uiControl = Control as Ooui.FormControl;
+			var uiControl = Control as Ooui.Html.FormControl;
 			if (uiControl == null)
 				return;
 			uiControl.IsDisabled = !Element.IsEnabled;

--- a/Ooui.Forms/Renderers/WebViewRenderer.cs
+++ b/Ooui.Forms/Renderers/WebViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.ComponentModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;

--- a/Ooui.Forms/VisualElementRenderer.cs
+++ b/Ooui.Forms/VisualElementRenderer.cs
@@ -14,7 +14,7 @@ namespace Ooui.Forms
         AutoPackage = 1 << 2
     }
 
-    public class VisualElementRenderer<TElement> : Ooui.Element, IVisualElementRenderer where TElement : VisualElement
+    public class VisualElementRenderer<TElement> : Ooui.Html.Element, IVisualElementRenderer where TElement : VisualElement
     {
         bool disposedValue = false; // To detect redundant calls
 
@@ -24,7 +24,7 @@ namespace Ooui.Forms
 
         VisualElement IVisualElementRenderer.Element => Element;
 
-        public Element NativeView => this;
+        public Ooui.Html.Element NativeView => this;
 
         event EventHandler<VisualElementChangedEventArgs> IVisualElementRenderer.ElementChanged {
             add { _elementChangedHandlers.Add (value); }
@@ -163,7 +163,7 @@ namespace Ooui.Forms
         {
         }
 
-        protected virtual void SendVisualElementInitialized (VisualElement element, Element nativeView)
+        protected virtual void SendVisualElementInitialized (VisualElement element, Html.Element nativeView)
         {
             element.SendViewInitialized (nativeView);
         }

--- a/Ooui.Forms/VisualElementRenderer.cs
+++ b/Ooui.Forms/VisualElementRenderer.cs
@@ -129,6 +129,10 @@ namespace Ooui.Forms
         public void SetElementSize (Size size)
         {
             Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion (Element, new Rectangle (Element.X, Element.Y, size.Width, size.Height));
+
+            foreach(var lv in Element.CollectElements<ListView>()) {
+                lv.UpdateChildrenSize();
+            }
         }
 
         public virtual void SetControlSize (Size size)

--- a/Ooui.Forms/VisualElementTracker.cs
+++ b/Ooui.Forms/VisualElementTracker.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Threading;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
+using Ooui.Forms.Extensions;
 
 namespace Ooui.Forms
 {
@@ -69,7 +70,8 @@ namespace Ooui.Forms
                 e.PropertyName == VisualElement.TranslationXProperty.PropertyName || e.PropertyName == VisualElement.TranslationYProperty.PropertyName || e.PropertyName == VisualElement.ScaleProperty.PropertyName ||
                 e.PropertyName == VisualElement.RotationProperty.PropertyName || e.PropertyName == VisualElement.RotationXProperty.PropertyName || e.PropertyName == VisualElement.RotationYProperty.PropertyName ||
                 e.PropertyName == VisualElement.IsVisibleProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
-                e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName)
+                e.PropertyName == VisualElement.InputTransparentProperty.PropertyName || e.PropertyName == VisualElement.OpacityProperty.PropertyName ||
+                e.PropertyName == ListView.ItemsSourceProperty.PropertyName)
                 UpdateNativeControl (); // poorly optimized
         }
 
@@ -103,6 +105,8 @@ namespace Ooui.Forms
             if (_isInteractive != shouldInteract) {
                 _isInteractive = shouldInteract;
             }
+
+            (_element as ListView)?.UpdateChildrenSize();
 
             var boundsChanged = _lastBounds != view.Bounds;
             var viewParent = view.RealParent as VisualElement;
@@ -192,6 +196,9 @@ namespace Ooui.Forms
 
         void SetElement (VisualElement oldElement, VisualElement newElement)
         {
+            var olv = oldElement as ListView;
+            var nlv = newElement as ListView;
+
             if (oldElement != null) {
                 oldElement.PropertyChanged -= _propertyChangedHandler;
                 oldElement.SizeChanged -= _sizeChangedEventHandler;

--- a/Ooui.Wasm/Ooui.Wasm.targets
+++ b/Ooui.Wasm/Ooui.Wasm.targets
@@ -1,23 +1,31 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<UsingTask TaskName="Ooui.Wasm.Build.Tasks.BuildDistTask" AssemblyFile="$(MSBuildThisFileDirectory)Ooui.Wasm.Build.Tasks.dll" />
+    <UsingTask 
+        TaskName="Ooui.Wasm.Build.Tasks.BuildDistTask"
+        AssemblyFile="$(MSBuildThisFileDirectory)Ooui.Wasm.Build.Tasks.dll"
+        Condition="Exists('$(MSBuildThisFileDirectory)Ooui.Wasm.Build.Tasks.dll')"/>
+  
+      <UsingTask 
+        TaskName="Ooui.Wasm.Build.Tasks.BuildDistTask"
+        AssemblyFile="$(MSBuildThisFileDirectory)/../Ooui.Wasm.Build.Tasks/bin/Debug/netstandard2.0/Ooui.Wasm.Build.Tasks.dll"
+        Condition="!Exists('$(MSBuildThisFileDirectory)Ooui.Wasm.Build.Tasks.dll')"/>
 
-	<!-- BuildDist -->
-	<PropertyGroup>
-		<CompileDependsOn>
-			$(CompileDependsOn);
-			BuildDist;
-		</CompileDependsOn>
-	</PropertyGroup>
+    <!-- BuildDist -->
+    <PropertyGroup>
+        <CompileDependsOn>
+            $(CompileDependsOn);
+            BuildDist;
+        </CompileDependsOn>
+    </PropertyGroup>
 
-	<Target Name="BuildDist" AfterTargets="AfterBuild" Condition="'$(_BuildDistAlreadyExecuted)'!='true'">
-		<PropertyGroup>
-			<_BuildDistAlreadyExecuted>true</_BuildDistAlreadyExecuted>
-		</PropertyGroup>
-		<BuildDistTask
-			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
-			OutputPath = "$(OutputPath)"
-			ReferencePath = "@(ReferencePath)" />
-	</Target>
+    <Target Name="BuildDist" AfterTargets="AfterBuild" Condition="'$(_BuildDistAlreadyExecuted)'!='true'">
+        <PropertyGroup>
+            <_BuildDistAlreadyExecuted>true</_BuildDistAlreadyExecuted>
+        </PropertyGroup>
+        <BuildDistTask
+            Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
+            OutputPath = "$(OutputPath)"
+            ReferencePath = "@(ReferencePath)" />
+    </Target>
 
 </Project>

--- a/Ooui.sln
+++ b/Ooui.sln
@@ -2,23 +2,25 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ooui", "Ooui\Ooui.csproj", "{DFDFD036-BF48-4D3A-BF99-88CA1EA8E4B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ooui", "Ooui\Ooui.csproj", "{DFDFD036-BF48-4D3A-BF99-88CA1EA8E4B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "Samples\Samples.csproj", "{CDF8BB01-40BB-402F-8446-47AA6F1628F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples", "Samples\Samples.csproj", "{CDF8BB01-40BB-402F-8446-47AA6F1628F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{78F6E9E7-4322-4F87-8CE9-1EEF1B16D268}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{78F6E9E7-4322-4F87-8CE9-1EEF1B16D268}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ooui.Forms", "Ooui.Forms\Ooui.Forms.csproj", "{DB819A2F-91E1-40FB-8D48-6544169966B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ooui.Forms", "Ooui.Forms\Ooui.Forms.csproj", "{DB819A2F-91E1-40FB-8D48-6544169966B8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ooui.AspNetCore", "Ooui.AspNetCore\Ooui.AspNetCore.csproj", "{2EDF0328-698B-458A-B10C-AB1B4786A6CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ooui.AspNetCore", "Ooui.AspNetCore\Ooui.AspNetCore.csproj", "{2EDF0328-698B-458A-B10C-AB1B4786A6CA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PlatformSamples", "PlatformSamples", "{12ADF328-BBA8-48FC-9AF1-F11B7921D9EA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreMvc", "PlatformSamples\AspNetCoreMvc\AspNetCoreMvc.csproj", "{7C6D477C-3378-4A86-9C31-AAD51204120B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreMvc", "PlatformSamples\AspNetCoreMvc\AspNetCoreMvc.csproj", "{7C6D477C-3378-4A86-9C31-AAD51204120B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ooui.Wasm.Build.Tasks", "Ooui.Wasm.Build.Tasks\Ooui.Wasm.Build.Tasks.csproj", "{6E9C9582-0DA8-4496-BAE0-23EFAF4A10C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ooui.Wasm.Build.Tasks", "Ooui.Wasm.Build.Tasks\Ooui.Wasm.Build.Tasks.csproj", "{6E9C9582-0DA8-4496-BAE0-23EFAF4A10C2}"
 EndProject
 Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "OouiTemplates", "Templates\OouiTemplates\OouiTemplates.csproj", "{7D3B32CF-38A3-40DE-8123-2E7A0D87104D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WasmFormsApp", "PlatformSamples\WasmFormsApp\WasmFormsApp.csproj", "{ABA00F85-03DC-4FBE-8858-C47601A2102A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -126,12 +128,25 @@ Global
 		{7D3B32CF-38A3-40DE-8123-2E7A0D87104D}.Release|x64.Build.0 = Release|Any CPU
 		{7D3B32CF-38A3-40DE-8123-2E7A0D87104D}.Release|x86.ActiveCfg = Release|Any CPU
 		{7D3B32CF-38A3-40DE-8123-2E7A0D87104D}.Release|x86.Build.0 = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|x64.Build.0 = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Debug|x86.Build.0 = Debug|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|x64.ActiveCfg = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|x64.Build.0 = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|x86.ActiveCfg = Release|Any CPU
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7C6D477C-3378-4A86-9C31-AAD51204120B} = {12ADF328-BBA8-48FC-9AF1-F11B7921D9EA}
+		{ABA00F85-03DC-4FBE-8858-C47601A2102A} = {12ADF328-BBA8-48FC-9AF1-F11B7921D9EA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9370DD6D-816D-4E0F-8356-835F65DCF3AA}

--- a/Ooui/Document.cs
+++ b/Ooui/Document.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 
 namespace Ooui
 {

--- a/Ooui/Html/Anchor.cs
+++ b/Ooui/Html/Anchor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ooui
+namespace Ooui.Html
 {
     public class Anchor : Element
     {

--- a/Ooui/Html/Body.cs
+++ b/Ooui/Html/Body.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Body : Element
     {
         public Body ()

--- a/Ooui/Html/Button.cs
+++ b/Ooui/Html/Button.cs
@@ -3,8 +3,7 @@ using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Button : FormControl
     {
         public ButtonType Type {

--- a/Ooui/Html/Canvas.cs
+++ b/Ooui/Html/Canvas.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Canvas : Element
     {
         CanvasRenderingContext2D context2d = new CanvasRenderingContext2D ();

--- a/Ooui/Html/CanvasRenderingContext2D.cs
+++ b/Ooui/Html/CanvasRenderingContext2D.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class CanvasRenderingContext2D : EventTarget
     {
         object fillStyle = "#000";

--- a/Ooui/Html/Div.cs
+++ b/Ooui/Html/Div.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Div : Element
     {
         protected override bool HtmlNeedsFullEndElement => true;

--- a/Ooui/Html/Element.cs
+++ b/Ooui/Html/Element.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public abstract class Element : Node
     {
         readonly Dictionary<string, object> attributes = new Dictionary<string, object> ();

--- a/Ooui/Html/Form.cs
+++ b/Ooui/Html/Form.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Form : Element
     {
         public string Action {

--- a/Ooui/Html/FormControl.cs
+++ b/Ooui/Html/FormControl.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public abstract class FormControl : Element
     {
         public string Name {

--- a/Ooui/Html/Heading.cs
+++ b/Ooui/Html/Heading.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Heading : Element
     {
         public Heading (int level = 1)

--- a/Ooui/Html/Iframe.cs
+++ b/Ooui/Html/Iframe.cs
@@ -1,8 +1,5 @@
-using System;
-
-namespace Ooui
-{
-    public class Image : Element
+﻿namespace Ooui.Html {
+    public class Iframe : Element
     {
         public string Source
         {
@@ -10,8 +7,8 @@ namespace Ooui
             set => SetAttributeProperty ("src", value);
         }
 
-        public Image ()
-            : base ("img")
+        public Iframe ()
+            : base ("iframe")
         {
         }
     }

--- a/Ooui/Html/Image.cs
+++ b/Ooui/Html/Image.cs
@@ -1,6 +1,7 @@
-﻿namespace Ooui
-{
-    public class Iframe : Element
+using System;
+
+namespace Ooui.Html {
+    public class Image : Element
     {
         public string Source
         {
@@ -8,8 +9,8 @@
             set => SetAttributeProperty ("src", value);
         }
 
-        public Iframe ()
-            : base ("iframe")
+        public Image ()
+            : base ("img")
         {
         }
     }

--- a/Ooui/Html/Input.cs
+++ b/Ooui/Html/Input.cs
@@ -3,8 +3,7 @@ using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Input : FormControl
     {
         public InputType Type {

--- a/Ooui/Html/Label.cs
+++ b/Ooui/Html/Label.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Label : Element
     {
         public Element For {

--- a/Ooui/Html/List.cs
+++ b/Ooui/Html/List.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class List : Element
     {
         public List (bool ordered = false)

--- a/Ooui/Html/ListItem.cs
+++ b/Ooui/Html/ListItem.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class ListItem : Element
     {
         public ListItem ()

--- a/Ooui/Html/Option.cs
+++ b/Ooui/Html/Option.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Option : Element
     {
         public string Value {

--- a/Ooui/Html/Paragraph.cs
+++ b/Ooui/Html/Paragraph.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Paragraph : Element
     {
         public Paragraph ()

--- a/Ooui/Html/Select.cs
+++ b/Ooui/Html/Select.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Linq;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Select : FormControl
     {
         bool gotValue = false;

--- a/Ooui/Html/Span.cs
+++ b/Ooui/Html/Span.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class Span : Element
     {
         public Span ()

--- a/Ooui/Html/TextArea.cs
+++ b/Ooui/Html/TextArea.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class TextArea : FormControl
     {
         public event TargetEventHandler Change {

--- a/Ooui/Html/TextInput.cs
+++ b/Ooui/Html/TextInput.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 
-namespace Ooui
-{
+namespace Ooui.Html {
     public class TextInput : Input
     {
         public event TargetEventHandler Input {

--- a/Ooui/Node.cs
+++ b/Ooui/Node.cs
@@ -35,6 +35,14 @@ namespace Ooui
                 return sb.ToString ();
             }
             set {
+                if (Children.Count == 1) {
+                    var textNode = Children[0] as TextNode;
+                    if (textNode != null) {
+                        textNode.Text = value;
+                        return;
+                    }
+                }
+
                 ReplaceAll (new TextNode (value ?? ""));
             }
         }

--- a/Ooui/Node.cs
+++ b/Ooui/Node.cs
@@ -1,3 +1,4 @@
+using Ooui.Html;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Ooui/Session.cs
+++ b/Ooui/Session.cs
@@ -5,6 +5,9 @@ namespace Ooui
 {
     public abstract class Session
     {
+        static int counter = 0;
+        public readonly int Id = counter++;
+
         protected readonly Element element;
         protected readonly double initialWidth;
         protected readonly double initialHeight;

--- a/Ooui/Session.cs
+++ b/Ooui/Session.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.Collections.Generic;
 
 namespace Ooui

--- a/Ooui/Style.cs
+++ b/Ooui/Style.cs
@@ -343,6 +343,11 @@ namespace Ooui
             set => this["z-index"] = value;
         }
 
+        public Value WhiteSpace {
+            get => this["white-space"];
+            set => this["white-space"] = value;
+        }
+
         public Value this[string propertyName] {
             get {
                 lock (properties) {

--- a/Ooui/UI.cs
+++ b/Ooui/UI.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net;
 using System.Runtime.InteropServices;
+using Ooui.Html;
 
 namespace Ooui
 {

--- a/Ooui/UI.cs
+++ b/Ooui/UI.cs
@@ -97,12 +97,12 @@ namespace Ooui
 
         public static void Publish (string path, Func<Element> elementCtor, bool disposeElementWhenDone = true)
         {
-            Publish (path, new ElementHandler (elementCtor, disposeElementWhenDone));
+            Publish (path, new ElementHandler (elementCtor, disposeElementWhenDone, !disposeElementWhenDone));
         }
 
-        public static void Publish (string path, Element element, bool disposeElementWhenDone = true)
+        public static void Publish (string path, Element element)
         {
-            Publish (path, () => element, disposeElementWhenDone);
+            Publish (path, () => element, false);
         }
 
         public static void PublishFile (string filePath)
@@ -333,16 +333,21 @@ namespace Ooui
         class ElementHandler : RequestHandler
         {
             readonly Lazy<Element> element;
+            readonly Func<Element> elementCtor;
 
             public bool DisposeElementWhenDone { get; }
 
-            public ElementHandler (Func<Element> ctor, bool disposeElementWhenDone)
+            public bool IsSharedElement{ get; }
+
+            public ElementHandler (Func<Element> ctor, bool disposeElementWhenDone, bool issharedElement = true)
             {
                 element = new Lazy<Element> (ctor);
+                elementCtor = ctor;
                 DisposeElementWhenDone = disposeElementWhenDone;
+                IsSharedElement = issharedElement;
             }
 
-            public Element GetElement () => element.Value;
+            public Element GetElement () => IsSharedElement ? element.Value : elementCtor();
 
             public override void Respond (HttpListenerContext listenerContext, CancellationToken token)
             {

--- a/Ooui/WebAssemblySession.cs
+++ b/Ooui/WebAssemblySession.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ooui.Html;
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Ooui/WebSocketSession.cs
+++ b/Ooui/WebSocketSession.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net;
 using System.Net.WebSockets;
+using Ooui.Html;
 
 namespace Ooui
 {

--- a/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
+++ b/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
+++ b/PlatformSamples/AspNetCoreMvc/AspNetCoreMvc.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PlatformSamples/AspNetCoreMvc/Controllers/SamplesController.cs
+++ b/PlatformSamples/AspNetCoreMvc/Controllers/SamplesController.cs
@@ -10,6 +10,7 @@ using Ooui;
 using Ooui.AspNetCore;
 using Samples;
 using System.Collections.Concurrent;
+using Ooui.Html;
 
 namespace AspNetCoreMvc.Controllers
 {

--- a/PlatformSamples/AspNetCoreMvc/Views/Shared/_Layout.cshtml
+++ b/PlatformSamples/AspNetCoreMvc/Views/Shared/_Layout.cshtml
@@ -40,9 +40,9 @@
         @RenderBody()
         <hr />
         <footer>
-            <p>Ooui @(typeof(Ooui.Element).Assembly.GetName().Version)</p>
+            <p>Ooui @(typeof(Ooui.Html.Element).Assembly.GetName().Version)</p>
             <p>&copy; 2017 - @DateTime.UtcNow.Year Frank A. Krueger</p>
-            @{ var e = new Ooui.Anchor ("https://github.com/praeclarum/Ooui", "π"); }
+            @{ var e = new Ooui.Html.Anchor ("https://github.com/praeclarum/Ooui", "π"); }
             <ooui element="e" />
             <!--Html.Ooui (e)-->
         </footer>

--- a/PlatformSamples/WasmFormsApp/MainPage.xaml
+++ b/PlatformSamples/WasmFormsApp/MainPage.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="WasmFormsApp.MainPage">
+    <Label
+        Text="Welcome to Xamarin.Forms on WebAssembly!"
+        VerticalOptions="CenterAndExpand"
+        HorizontalOptions="CenterAndExpand" />
+</ContentPage>

--- a/PlatformSamples/WasmFormsApp/MainPage.xaml.cs
+++ b/PlatformSamples/WasmFormsApp/MainPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace WasmFormsApp
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class MainPage : ContentPage
+	{
+		public MainPage ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/PlatformSamples/WasmFormsApp/Program.cs
+++ b/PlatformSamples/WasmFormsApp/Program.cs
@@ -1,0 +1,14 @@
+﻿using Ooui;
+using Xamarin.Forms;
+
+namespace WasmFormsApp {
+	class Program
+    {
+        static void Main(string[] args)
+        {
+			Forms.Init ();
+
+			UI.Publish ("/", new MainPage ().GetOouiElement ());
+		}
+    }
+}

--- a/PlatformSamples/WasmFormsApp/WasmFormsApp.csproj
+++ b/PlatformSamples/WasmFormsApp/WasmFormsApp.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\Ooui.Wasm\Ooui.Wasm.targets" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ooui.Forms\Ooui.Forms.csproj" />
+    <ProjectReference Include="..\..\Ooui\Ooui.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="MainPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ msbuild
 dotnet run --project Samples/Samples.csproj --no-build
 ```
 
-*(There is currently an issue with Xamarin.Forms and building from the dotnet cli, so for now we use the msbuild command and then set the --no-build flag on dotnet run but this will eventually change when the issue is resolved.)*
-
 This will open the default starting page for the Samples. Now point your browser at [http://localhost:8080/shared-button](http://localhost:8080/shared-button)
 
 You should see a button that tracks the number of times it was clicked. The source code for that button is shown in the example below.

--- a/Samples/BoxViewClockSample.cs
+++ b/Samples/BoxViewClockSample.cs
@@ -9,7 +9,7 @@ namespace Samples
 
         BoxViewClockPage page;
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             //
             // Always return the same page because the code never stops the timer

--- a/Samples/BugSweeperSample.cs
+++ b/Samples/BugSweeperSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms BugSweeper";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var page = new BugSweeper.BugSweeperPage ();
             return page.GetOouiElement ();

--- a/Samples/ButtonSample.cs
+++ b/Samples/ButtonSample.cs
@@ -1,5 +1,6 @@
 using System;
 using Ooui;
+using Ooui.Html;
 
 namespace Samples
 {

--- a/Samples/ButtonXamlSample.cs
+++ b/Samples/ButtonXamlSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Button XAML";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var page = new ButtonXaml.ButtonXamlPage ();
             return page.GetOouiElement ();

--- a/Samples/DisplayAlertSample.cs
+++ b/Samples/DisplayAlertSample.cs
@@ -8,7 +8,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms DisplayAlert";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var page = new DisplayAlertPage ();
             return page.GetOouiElement ();

--- a/Samples/DotMatrixClockSample.cs
+++ b/Samples/DotMatrixClockSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms DoMatrixClock";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new DotMatrixClock.DotMatrixClockPage();
             return page.GetOouiElement();

--- a/Samples/DrawSample.cs
+++ b/Samples/DrawSample.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ooui;
+using Ooui.Html;
 
 namespace Samples
 {

--- a/Samples/EditorSample.cs
+++ b/Samples/EditorSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Editor Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/FilesSample.cs
+++ b/Samples/FilesSample.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using Ooui;
+using Ooui.Html;
 
 namespace Samples
 {

--- a/Samples/ISample.cs
+++ b/Samples/ISample.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Ooui;
+using Ooui.Html;
 
 namespace Samples
 {

--- a/Samples/ListViewSample.cs
+++ b/Samples/ListViewSample.cs
@@ -60,7 +60,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Basic Entry ListView Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 
@@ -99,7 +99,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Basic Switch ListView Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/MonkeysSample.cs
+++ b/Samples/MonkeysSample.cs
@@ -10,7 +10,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Monkeys";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new Monkeys.Views.MonkeysView();
             return page.GetOouiElement();

--- a/Samples/Navigation/NavigationFirstPage.xaml
+++ b/Samples/Navigation/NavigationFirstPage.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Samples.Navigation.NavigationFirstPage"
+             Title="The First Page">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="This is the first page."
+                VerticalOptions="Center" 
+                HorizontalOptions="CenterAndExpand" />
+            <Button Clicked="Button_Clicked" 
+                    Text="Navigate to Second Page" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Samples/Navigation/NavigationFirstPage.xaml.cs
+++ b/Samples/Navigation/NavigationFirstPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Samples.Navigation
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class NavigationFirstPage : ContentPage
+	{
+		public NavigationFirstPage ()
+		{
+			InitializeComponent ();
+          
+		}
+
+        private void Button_Clicked(object sender, EventArgs e)
+        {
+            (this.Parent as NavigationPage).PushAsync(new Navigation.NavigationSecondPage());
+        }
+
+     
+    }
+}

--- a/Samples/Navigation/NavigationSecondPage.xaml
+++ b/Samples/Navigation/NavigationSecondPage.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Samples.Navigation.NavigationSecondPage"
+             Title="The Second Page">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="This is the second page."
+                VerticalOptions="Center" 
+                HorizontalOptions="CenterAndExpand" />
+            <Button Clicked="BackButton_Clicked" 
+                    Text="Go back to First Page" />
+            <Button Clicked="Button_Clicked" 
+                    Text="Navigate to Third Page" />
+            
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Samples/Navigation/NavigationSecondPage.xaml.cs
+++ b/Samples/Navigation/NavigationSecondPage.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Samples.Navigation
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class NavigationSecondPage : ContentPage
+	{
+		public NavigationSecondPage ()
+		{
+			InitializeComponent ();
+		}
+
+        private void BackButton_Clicked(object sender, EventArgs e)
+        {
+            (this.Parent as NavigationPage).PopAsync();
+        }
+
+        private void Button_Clicked(object sender, EventArgs e)
+        {
+            (this.Parent as NavigationPage).PushAsync(new Navigation.NavigationThirdPage());
+        }
+
+    }
+}

--- a/Samples/Navigation/NavigationThirdPage.xaml
+++ b/Samples/Navigation/NavigationThirdPage.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Samples.Navigation.NavigationThirdPage"
+             Title="The Third Page">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="This is the third page."
+                VerticalOptions="Center" 
+                HorizontalOptions="CenterAndExpand" />
+            <Button Clicked="BackButton_Clicked" 
+                    Text="Go back to Second Page" />
+            <Button Clicked="RootButton_Clicked" 
+                    Text="Go back to Root (1st page)" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Samples/Navigation/NavigationThirdPage.xaml.cs
+++ b/Samples/Navigation/NavigationThirdPage.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Samples.Navigation
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class NavigationThirdPage : ContentPage
+	{
+		public NavigationThirdPage ()
+		{
+			InitializeComponent ();
+		}
+
+        private void BackButton_Clicked(object sender, EventArgs e)
+        {
+            (this.Parent as NavigationPage).PopAsync(false);
+        }
+
+        private void RootButton_Clicked(object sender, EventArgs e)
+        {
+            (this.Parent as NavigationPage).PopToRootAsync(false);
+        }
+
+    }
+}

--- a/Samples/NavigationSample.cs
+++ b/Samples/NavigationSample.cs
@@ -1,0 +1,18 @@
+﻿
+using Ooui;
+using Xamarin.Forms;
+
+namespace Samples.Navigation
+{
+    public class NavigationSample : ISample
+    {
+        public string Title => "Xamarin.Forms Navigation XAML";
+
+        public Ooui.Element CreateElement()
+        {
+            var page = new Navigation.NavigationFirstPage();
+            var root = new NavigationPage(page);
+            return root.GetOouiElement();
+        }
+    }
+}

--- a/Samples/NavigationSample.cs
+++ b/Samples/NavigationSample.cs
@@ -8,11 +8,15 @@ namespace Samples.Navigation
     {
         public string Title => "Xamarin.Forms Navigation XAML";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new Navigation.NavigationFirstPage();
             var root = new NavigationPage(page);
             return root.GetOouiElement();
+        }
+
+        public void Publish() {
+            UI.Publish("/navigation", CreateElement);
         }
     }
 }

--- a/Samples/PickerSample.cs
+++ b/Samples/PickerSample.cs
@@ -24,7 +24,7 @@ namespace Samples
 			"orange",
 		};
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -34,6 +34,7 @@ namespace Samples
             new DotMatrixClockSample().Publish();
             new EditorSample().Publish();
             new MonkeysSample().Publish();
+            new Navigation.NavigationSample().Publish();
             new RefreshListViewSample ().Publish ();
             new SearchBarSample().Publish();
             new SliderSample().Publish();

--- a/Samples/RefreshListViewSample.cs
+++ b/Samples/RefreshListViewSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms RefreshListView";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var page = new RefreshListView();
             return page.GetOouiElement ();

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Samples/SearchBarSample.cs
+++ b/Samples/SearchBarSample.cs
@@ -13,7 +13,7 @@ namespace Samples
         
         public string Title => "Xamarin.Forms SearchBar";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/SliderSample.cs
+++ b/Samples/SliderSample.cs
@@ -10,7 +10,7 @@ namespace Samples
 
         public string Title => "Xamarin.Forms Slider Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/SwitchErrorSample.cs
+++ b/Samples/SwitchErrorSample.cs
@@ -8,7 +8,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Switch Error";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var layout = new StackLayout();
             var label = new Xamarin.Forms.Label

--- a/Samples/TimePickerSample.cs
+++ b/Samples/TimePickerSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms TimePicker Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/TipCalcSample.cs
+++ b/Samples/TipCalcSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms TipCalc";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new TipCalc.TipCalcPage();
             return page.GetOouiElement();

--- a/Samples/TodoSample.cs
+++ b/Samples/TodoSample.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ooui;
+using Ooui.Html;
 
 namespace Samples
 {

--- a/Samples/WeatherAppSample.cs
+++ b/Samples/WeatherAppSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms WeatherApp";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new WeatherApp.WeatherPage();
             return page.GetOouiElement();

--- a/Samples/WebViewSample.cs
+++ b/Samples/WebViewSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms WebView Sample";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var panel = new StackLayout();
 

--- a/Samples/WrappingTextSample.cs
+++ b/Samples/WrappingTextSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Wrapping Text";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var rows = new StackLayout { Orientation = StackOrientation.Vertical };
 

--- a/Samples/XamlPreviewPageSample.cs
+++ b/Samples/XamlPreviewPageSample.cs
@@ -9,7 +9,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms XAML Editor";
 
-        public Ooui.Element CreateElement ()
+        public Ooui.Html.Element CreateElement ()
         {
             var page = new XamlEditorPage ();
             return page.GetOouiElement ();

--- a/Samples/XuzzleSample.cs
+++ b/Samples/XuzzleSample.cs
@@ -7,7 +7,7 @@ namespace Samples
     {
         public string Title => "Xamarin.Forms Xuzzle";
 
-        public Ooui.Element CreateElement()
+        public Ooui.Html.Element CreateElement()
         {
             var page = new Xuzzle.XuzzlePage();
             return page.GetOouiElement();

--- a/Tests/ButtonTests.cs
+++ b/Tests/ButtonTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/CanvasTests.cs
+++ b/Tests/CanvasTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/EventTargetStressTests.cs
+++ b/Tests/EventTargetStressTests.cs
@@ -12,6 +12,7 @@ using Ooui;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/EventTargetTests.cs
+++ b/Tests/EventTargetTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/InputTests.cs
+++ b/Tests/InputTests.cs
@@ -18,7 +18,7 @@ namespace Tests
         [TestMethod]
         public void ValuePropertyChangedOnReceiver ()
         {
-            var e = new Ooui.Input ();
+            var e = new Ooui.Html.Input ();
             var count = 0;
             e.PropertyChanged += (s, ev) => {
                 if (ev.PropertyName == "Value")

--- a/Tests/JsonTests.cs
+++ b/Tests/JsonTests.cs
@@ -12,6 +12,7 @@ using Ooui;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Text;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/MessageSendTests.cs
+++ b/Tests/MessageSendTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/NodeTests.cs
+++ b/Tests/NodeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 #if NUNIT
 using NUnit.Framework;
@@ -68,5 +69,48 @@ namespace Tests
             p.Receive (Message.Event (b.Id, "change", "please work"));
             Assert.AreEqual ("please work", b.Value);
         }
+
+        [TestMethod]
+        public void Text ()
+        {
+            var div = new Div ();
+
+            // Log tracks all messages sent due to updates
+            var log = new StringBuilder ();
+            log.AppendLine ();
+            void Parent_MessageSent (Message obj)
+            {
+                log.AppendLine (obj.ToString ());
+            }
+            div.MessageSent += Parent_MessageSent;
+
+            var divId = div.Id;
+
+            log.AppendLine ("#1 - Inserts new text node");
+            div.Text = "Hello";
+
+            Assert.AreEqual (1, div.Children.Count);
+            var text = div.Children[0];
+            var textId = text.Id;
+
+            Assert.AreEqual ("Hello", div.Text);
+            Assert.AreEqual ("Hello", text.Text);
+
+            log.AppendLine ("#2 - Sets text node text to There");
+            div.Text = "There";
+            Assert.AreEqual ("There", div.Text);
+            Assert.AreEqual ("There", text.Text);
+
+            var expected = string.Format(@"
+#1 - Inserts new text node
+{{""m"":""call"",""id"":""{0}"",""k"":""insertBefore"",""v"":[""{1}"",null]}}
+#2 - Sets text node text to There
+{{""m"":""set"",""id"":""{1}"",""k"":""data"",""v"":""There""}}
+", divId, textId).Replace ("\r\n", "\n");
+
+            var actual = log.ToString ().Replace ("\r\n", "\n");
+            Assert.AreEqual (expected, actual);
+        }
+
     }
 }

--- a/Tests/NodeTests.cs
+++ b/Tests/NodeTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/WindowTests.cs
+++ b/Tests/WindowTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {

--- a/Tests/WriteHtmlTests.cs
+++ b/Tests/WriteHtmlTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
 using Ooui;
+using Ooui.Html;
 
 namespace Tests
 {


### PR DESCRIPTION
After the commit https://github.com/praeclarum/Ooui/commit/92e9b9bee452d14676d09c43b8aeb22676d6d32b the session handling broke if you are using the default `Publish`,
resulting in disposing the entire shared sessien as soon as one client diconnects.
A "not shared" session was also not possible due to the lazy loading in the `ElementHandler` class.

### This PR addresses following points:

- Adding a switch to the `ElementHandler` class to handle 'not shared' elements.
- Set the default behavior of the `void Publish (string, Element, bool)` to a shared element.
- Add the property `Style.WhiteSpace` and set it to `pre-wrap` for the Xamarin.Forms Label to display newlines and tabs correctly.

This should fix the Issues https://github.com/praeclarum/Ooui/issues/172 and https://github.com/praeclarum/Ooui/issues/162

