### PR TITLE
Use https path for mono submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Ooui.Wasm.Build.Tasks/linker"]
 	path = Ooui.Wasm.Build.Tasks/linker
-	url = git@github.com:mono/linker.git
+	url = https://github.com/mono/linker.git


### PR DESCRIPTION
Allow contributors to initialize the mono submodule by calling `git submodule update --init --recursive`. Since mono contains another submodule one could perhaps think about adding a little script in the root folder which would get all the submodules?