### PR TITLE
Fixing layouts of Ooui.Forms ViewCells

### DIFF
--- a/Ooui.Forms/Renderers/ListViewRenderer.cs
+++ b/Ooui.Forms/Renderers/ListViewRenderer.cs
@@ -79,6 +79,8 @@ namespace Ooui.Forms.Renderers
 
             if (disposing && !_disposed) {
 
+                ClearPrototype();
+
                 if (Element != null) {
                     var templatedItems = TemplatedItemsView.TemplatedItems;
                     templatedItems.CollectionChanged -= OnCollectionChanged;
@@ -86,6 +88,17 @@ namespace Ooui.Forms.Renderers
                 }
 
                 _disposed = true;
+            }
+        }
+
+        void ClearPrototype()
+        {
+            if (_prototype != null)
+            {
+                var element = _prototype.Element;
+                element?.ClearValue(Platform.RendererProperty);
+                _prototype?.Dispose();
+                _prototype = null;
             }
         }
 

--- a/Ooui.Forms/Renderers/ListViewRenderer.cs
+++ b/Ooui.Forms/Renderers/ListViewRenderer.cs
@@ -11,7 +11,17 @@ namespace Ooui.Forms.Renderers
 {
     public class ListViewRenderer : ViewRenderer<ListView, List>
     {
+        const int DefaultRowHeight = 44;
         private bool _disposed;
+        IVisualElementRenderer _prototype;
+
+        int _rowHeight;
+
+        public int RowHeight
+        {
+            get => _rowHeight;
+            set => _rowHeight = value;
+        }
 
         public ListViewRenderer ()
         {
@@ -32,6 +42,10 @@ namespace Ooui.Forms.Renderers
                     var list = new List ();
                     list.Style.Overflow = "scroll";
                     list.Style.Padding = "0";
+                    // Make the list element positioned so child elements will
+                    // be positioned relative to it. This will allow the list
+                    // to scroll properly.
+                    list.Style.Position = "relative";
 
                     SetNativeControl (list);
                 }
@@ -39,6 +53,8 @@ namespace Ooui.Forms.Renderers
                 var templatedItems = TemplatedItemsView.TemplatedItems;
                 templatedItems.CollectionChanged += OnCollectionChanged;
                 e.NewElement.ScrollToRequested += ListView_ScrollToRequested;
+
+                UpdateRowHeight();
 
                 UpdateItems ();
                 UpdateBackgroundColor ();
@@ -121,11 +137,22 @@ namespace Ooui.Forms.Renderers
             }
             else {
                 var i = 0;
+                double offset = 0;
                 foreach (var item in items) {
                     var li = listItems[i];
+                    var nativeCell = items[i];
                     var children = li.Children;
                     var rv = children.Count > 0 ? children[0] as CellElement : null;
                     var cell = GetCell (item, rv);
+                    var height = CalculateHeightForCell(nativeCell);
+                    li.Style.Height = height;
+                    var viewCell = (ViewCell)cell.Cell;
+                    if (viewCell != null && viewCell.View != null)
+                    {
+                        var rect = new Rectangle(0, offset, Element.Width, height);
+                        Layout.LayoutChildIntoBoundingRegion(viewCell.View, rect);
+                    }
+                    offset += height;
                     if (rv == null) {
                         li.AppendChild (cell);
                     }
@@ -158,6 +185,56 @@ namespace Ooui.Forms.Renderers
                 case ScrollToPosition.End:
                     Control.Send (Ooui.Message.Set (Control.Id, "scrollTop", new Ooui.Message.PropertyReference { TargetId = Control.Id, Key = "scrollHeight" }));
                     break;
+            }
+        }
+
+        void UpdateRowHeight()
+        {
+            var rowHeight = Element.RowHeight;
+            if (Element.HasUnevenRows && rowHeight == -1)
+                RowHeight = -1;
+            else
+                RowHeight = rowHeight <= 0 ? DefaultRowHeight : rowHeight;
+        }
+
+        internal double CalculateHeightForCell(Cell cell)
+        {  
+            if (!Element.HasUnevenRows)
+            {
+                return RowHeight;
+            } 
+            else 
+            {
+                var viewCell = cell as ViewCell;
+                if (viewCell != null && viewCell.View != null)
+                {
+                    var target = viewCell.View;
+                    if (_prototype == null)
+                        _prototype = Platform.CreateRenderer(target);
+                    else
+                        _prototype.SetElement(target);
+
+                    Platform.SetRenderer(target, _prototype);
+
+                    var req = target.Measure(Element.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+
+                    target.ClearValue(Platform.RendererProperty);
+                    foreach (Xamarin.Forms.Element descendant in target.Descendants())
+                    {
+                        IVisualElementRenderer renderer = Platform.GetRenderer(descendant as VisualElement);
+
+                        // Clear renderer from descendent; this will not happen in Dispose as normal because we need to
+                        // unhook the Element from the renderer before disposing it.
+                        descendant.ClearValue(Platform.RendererProperty);
+                        renderer?.Dispose();
+                        renderer = null;
+                    }
+
+                    var height = req.Request.Height;
+                    return height > 1 ? height : DefaultRowHeight;
+                }
+                var renderHeight = cell.RenderHeight;
+                return renderHeight > 0 ? renderHeight : DefaultRowHeight;
             }
         }
 


### PR DESCRIPTION
This PR makes an attempt at fixing the layout of custom views in list cells. Previously the necessary information was not provided to Xamarin.Forms for it to provide positioning information for custom cell views. As a part of providing this information list cells needed to have a defined height. Now the code has a default row height (borrowed from iOS) and it will respect row heights provided from Xamarin.Forms. Additionally an attempt was made to support list views that have uneven row heights.

The majority of this fix was adopted from the Xamarin Forms iOS renderer. Though I did squeeze all of it into the ListViewRenderer for a couple of reasons.

1. On iOS some of the attributes are stored in the native view elements. I elected not to do this so Ooui elements did gain attributes that were only needed by Ooui.Forms.
2. The iOS renderer needed to implement table view data sources, which aren't necessary for Ooui. I condensed row rendering logic from the iOS datasources into the ListViewRenderer.