### PR TITLE
Image Display fixes for Ooui.Forms

### DIFF
--- a/Ooui.Forms/Renderers/ImageRenderer.cs
+++ b/Ooui.Forms/Renderers/ImageRenderer.cs
@@ -138,7 +138,7 @@ namespace Ooui.Forms.Renderers
                     return;
 
                 var imageView = Control;
-                if (imageView != null)
+                if (imageView != null && uiimage != null)
                     imageView.Source = uiimage;
 
                 ((IVisualElementController)Element).NativeSizeChanged ();

--- a/Ooui.Forms/Renderers/ImageRenderer.cs
+++ b/Ooui.Forms/Renderers/ImageRenderer.cs
@@ -9,6 +9,8 @@ namespace Ooui.Forms.Renderers
     public class ImageRenderer : ViewRenderer<Xamarin.Forms.Image, Ooui.Image>
     {
         bool _isDisposed;
+        double ClientHeight = -1;
+        double ClientWidth = -1;
 
         protected override void Dispose (bool disposing)
         {
@@ -50,25 +52,38 @@ namespace Ooui.Forms.Renderers
             else if (e.PropertyName == Xamarin.Forms.Image.IsOpaqueProperty.PropertyName)
                 SetOpacity ();
             else if (e.PropertyName == Xamarin.Forms.Image.AspectProperty.PropertyName)
-                SetAspect ();
+                SetAspect();
+            else if (e.PropertyName == VisualElement.WidthProperty.PropertyName)
+                SetDimensions ();
         }
 
         void OnLoad(object sender, EventArgs eventArgs)
         {
             var args = (TargetEventArgs)eventArgs;
+            ClientHeight = args.ClientHeight;
+            ClientWidth = args.ClientWidth;
+
+            SetDimensions();
+        }
+
+        void SetDimensions()
+        {
             var b = Element.Bounds;
             double scale = 1;
 
+            if (ClientWidth < 0 || ClientHeight < 0)
+                return;
+
             if (Math.Abs(b.Width) > 0)
             {
-                scale = b.Width / args.ClientWidth;
+                scale = b.Width / ClientWidth;
                 Element.WidthRequest = b.Width;
-                Element.HeightRequest = scale * args.ClientHeight;
+                Element.HeightRequest = scale * ClientHeight;
             }
             else if (Math.Abs(b.Height) > 0)
             {
-                scale = b.Height / args.ClientHeight;
-                Element.WidthRequest = scale * args.ClientWidth;
+                scale = b.Height / ClientHeight;
+                Element.WidthRequest = scale * ClientWidth;
                 Element.HeightRequest = b.Height;
             }
             else

--- a/Ooui.Forms/Renderers/ImageRenderer.cs
+++ b/Ooui.Forms/Renderers/ImageRenderer.cs
@@ -29,6 +29,8 @@ namespace Ooui.Forms.Renderers
                 var imageView = new Ooui.Image ();
                 SetNativeControl (imageView);
                 this.Style.Overflow = "hidden";
+
+                Control.Loaded += OnLoad;
             }
 
             if (e.NewElement != null) {
@@ -49,6 +51,30 @@ namespace Ooui.Forms.Renderers
                 SetOpacity ();
             else if (e.PropertyName == Xamarin.Forms.Image.AspectProperty.PropertyName)
                 SetAspect ();
+        }
+
+        void OnLoad(object sender, EventArgs eventArgs)
+        {
+            var args = (TargetEventArgs)eventArgs;
+            var b = Element.Bounds;
+            double scale = 1;
+
+            if (Math.Abs(b.Width) > 0)
+            {
+                scale = b.Width / args.ClientWidth;
+                Element.WidthRequest = b.Width;
+                Element.HeightRequest = scale * args.ClientHeight;
+            }
+            else if (Math.Abs(b.Height) > 0)
+            {
+                scale = b.Height / args.ClientHeight;
+                Element.WidthRequest = scale * args.ClientWidth;
+                Element.HeightRequest = b.Height;
+            }
+            else
+            {
+                // We can't really know what to do in this case
+            }
         }
 
         void SetAspect ()

--- a/Ooui/Client.js
+++ b/Ooui/Client.js
@@ -37,6 +37,10 @@ const inputEvents = {
     keyup: true,
 };
 
+const elementEvents = {
+    load: true
+}
+
 function getSize () {
     return {
         height: window.innerHeight,
@@ -303,6 +307,12 @@ function msgListen (m) {
                 offsetX: e.offsetX,
                 offsetY: e.offsetY,
             };
+        }
+        else if (elementEvents[m.k]) {
+            em.v = {
+                clientHeight: node.clientHeight,
+                clientWidth: node.clientWidth
+            }
         }
         const ems = JSON.stringify (em);
         send (ems);

--- a/Ooui/Element.cs
+++ b/Ooui/Element.cs
@@ -52,7 +52,12 @@ namespace Ooui
             add => AddEventListener ("keyup", value);
             remove => RemoveEventListener ("keyup", value);
         }
-
+        
+        public event TargetEventHandler Loaded {
+            add => AddEventListener ("load", value);
+            remove => RemoveEventListener ("load", value);
+        }
+        
         public event TargetEventHandler MouseDown {
             add => AddEventListener ("mousedown", value);
             remove => RemoveEventListener ("mousedown", value);

--- a/Ooui/EventTarget.cs
+++ b/Ooui/EventTarget.cs
@@ -220,8 +220,16 @@ namespace Ooui
             if (handlers != null) {
                 var args = new TargetEventArgs ();
                 if (message.Value is Newtonsoft.Json.Linq.JObject o) {
-                    args.OffsetX = (double)o["offsetX"];
-                    args.OffsetY = (double)o["offsetY"];
+                    if (o["offsetX"] != null)
+                    {
+                        args.OffsetX = (double)o["offsetX"];
+                        args.OffsetY = (double)o["offsetY"];
+                    }
+                    if (o["clientHeight"] != null)
+                    {
+                        args.ClientHeight = (double)o.GetValue("clientHeight");
+                        args.ClientWidth = (double)o.GetValue("clientWidth");
+                    }
                 }
                 foreach (var h in handlers) {
                     h.Invoke (this, args);
@@ -257,5 +265,7 @@ namespace Ooui
     {
         public double OffsetX { get; set; }
         public double OffsetY { get; set; }
+        public double ClientHeight { get; set; }
+        public double ClientWidth { get; set; }
     }
 }


### PR DESCRIPTION
This pull request fixes two issues related to image views.

### Image Scaling and Rendering
Previously Image views that did not have a defined height and width could not be laid our properly by Xamarin.Forms. Other elements would render on top of them because Xamarin.Forms wasn't able to calculate the bounds of the view. Additionally images would always be displayed at their full resolution even if that meant the image would overflow out of the bounding box. Now Image dimensions are sent from the client as a part of the load event. These dimensions are then used to scale the image into the bounding box of the image view.

### "Missing Image" Icon displayed incorrectly
When an image view does not have a source image the src attribute of the image element was incorrectly set to `/images/undefined`. This would cause the "Missing Image" icon to be displayed in the browser when the image element legitimately didn't have a source image.

At this point I'm not sure if this fix perfectly duplicates the behaviors of the native iOS and Android views, but it fixes the image rendering issues in our app.