### PR TITLE
Issue #219 - Implement GetStreamAsync & GetMD5Hash for OouiPlatformServices

### DIFF
--- a/Ooui.Forms/Renderers/ImageRenderer.cs
+++ b/Ooui.Forms/Renderers/ImageRenderer.cs
@@ -213,7 +213,7 @@ namespace Ooui.Forms.Renderers
                         using (var outputStream = new System.IO.MemoryStream (data)) {
                             await streamImage.CopyToAsync (outputStream, 4096, cancelationToken).ConfigureAwait (false);
                         }
-                        var hash = Ooui.Utilities.Hash (data);
+                        var hash = Ooui.Utilities.GetShaHash (data);
                         var etag = "\"" + hash + "\"";
                         image = "/images/" + hash;
                         if (Ooui.UI.TryGetFileContentAtPath (image, out var file) && file.Etag == etag) {

--- a/Ooui/UI.cs
+++ b/Ooui/UI.cs
@@ -85,7 +85,7 @@ namespace Ooui
                     clientJsBytes = Encoding.UTF8.GetBytes (r.ReadToEnd ());
                 }
             }
-            clientJsEtag = "\"" + Utilities.Hash (clientJsBytes) + "\"";
+            clientJsEtag = "\"" + Utilities.GetShaHash (clientJsBytes) + "\"";
         }
 
         static void Publish (string path, RequestHandler handler)
@@ -117,13 +117,13 @@ namespace Ooui
             if (contentType == null) {
                 contentType = GuessContentType (path, filePath);
             }
-            var etag = "\"" + Utilities.Hash (data) + "\"";
+            var etag = "\"" + Utilities.GetShaHash (data) + "\"";
             Publish (path, new DataHandler (data, etag, contentType));
         }
 
         public static void PublishFile (string path, byte[] data, string contentType)
         {
-            var etag = "\"" + Utilities.Hash (data) + "\"";
+            var etag = "\"" + Utilities.GetShaHash (data) + "\"";
             Publish (path, new DataHandler (data, etag, contentType));
         }
 
@@ -168,7 +168,7 @@ namespace Ooui
         public static void PublishJson (string path, object value)
         {
             var data = JsonHandler.GetData (value);
-            var etag = "\"" + Utilities.Hash (data) + "\"";
+            var etag = "\"" + Utilities.GetShaHash (data) + "\"";
             Publish (path, new DataHandler (data, etag, JsonHandler.ContentType));
         }
 

--- a/Ooui/Utilities.cs
+++ b/Ooui/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Ooui
@@ -6,21 +7,54 @@ namespace Ooui
     public static class Utilities
     {
         [ThreadStatic]
-        static System.Security.Cryptography.SHA256 sha256;
+        static SHA256 sha256;
 
-        public static string Hash (byte[] bytes)
+        [ThreadStatic]
+        static MD5 md5;
+
+        public static string GetShaHash(byte[] bytes)
         {
             var sha = sha256;
-            if (sha == null) {
-                sha = System.Security.Cryptography.SHA256.Create ();
+            if (sha == null)
+            {
+                sha = SHA256.Create();
                 sha256 = sha;
             }
-            var data = sha.ComputeHash (bytes);
-            StringBuilder sBuilder = new StringBuilder ();
-            for (int i = 0; i < data.Length; i++) {
-                sBuilder.Append (data[i].ToString ("x2"));
+            var data = sha.ComputeHash(bytes);
+
+            return BytesToString(data);
+        }
+
+        public static string GetMd5Hash(string input)
+        {
+            var md = md5;
+            if (md == null)
+            {
+                md = MD5.Create();
+                md5 = md;
             }
-            return sBuilder.ToString ();
+            
+            // Convert the input string to a byte array and compute the hash.
+            byte[] data = md.ComputeHash(Encoding.UTF8.GetBytes(input));
+
+            return BytesToString(data);
+        }
+
+        private static string BytesToString(byte[] data)
+        {
+            // Create a new Stringbuilder to collect the bytes
+            // and create a string.
+            StringBuilder sBuilder = new StringBuilder();
+
+            // Loop through each byte of the hashed data 
+            // and format each one as a hexadecimal string.
+            for (int i = 0; i < data.Length; i++)
+            {
+                sBuilder.Append(data[i].ToString("x2"));
+            }
+
+            // Return the hexadecimal string.
+            return sBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
Also provides an optional way to ignore certificate errors.

In order to implement a solution described by michael-watson in #104 (comment), I have extended OouiPlatformServices on a local clone of Ooui. Shortly, I'll submit a PR for this case.

If interested, I can also include a UriNoCacheImageSource class that is the UriImageSource class without any caching in it.